### PR TITLE
Use uint8 datatype and no nodata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data
 images
 utilities/pipa_paper/venv/
+.idea/

--- a/utilities/pipa_paper/density_totiff_batch.py
+++ b/utilities/pipa_paper/density_totiff_batch.py
@@ -44,7 +44,7 @@ def create_tifs(extra, cellsize):
 
     for f in onlyfiles:
         if ".npy" in f:
-            grid = np.load(source_dir + extra+ f)
+            grid = np.load(source_dir + extra+ f).astype(profile['dtype'])
             out_tif = out_dir + extra + f.replace('.npy',".tif")
             with rio.open(out_tif, 'w', **profile) as dst:
                 dst.write(grid, indexes=1)

--- a/utilities/pipa_paper/density_totiff_batch.py
+++ b/utilities/pipa_paper/density_totiff_batch.py
@@ -33,8 +33,8 @@ def create_tifs(extra, cellsize):
 
     profile = {
         'crs': 'EPSG:4326',
-        'nodata': -9999,
-        'dtype': rio.float64,
+        'nodata': None,
+        'dtype': rio.uint8,
         'height': nrows,
         'width': ncols,
         'count': 1,


### PR DESCRIPTION
The tif files are all encoded as `float64`, which not all systems can open, and it makes the files much larger than they need to be.  Looks like the absolute max across all the files is `21`, so we can use a `uint8` and a `null` nodata value.  Both changes in this PR, but only for the batch processing script.

``` python
import rasterio as rio
import multiprocessing as mp
from glob import glob


def _process(infile):
    with rio.open(infile) as src:
        return src.read(1).max()


values = list(mp.Pool(4).imap_unordered(_process, glob('figure_raster_data/*/*.tif'), 25))

print(len(values))
print(min(values))
print(max(values))

543
1.0
21.0
```
